### PR TITLE
Fjerner CPU-limit

### DIFF
--- a/.build/gcp-nais-dev.yaml
+++ b/.build/gcp-nais-dev.yaml
@@ -11,7 +11,6 @@ spec:
   replicas:
     min: 1
     max: 2
-    cpuThresholdPercentage: 50
   port: 8080
   liveness:
     path: /status
@@ -35,7 +34,6 @@ spec:
 
   resources:
     limits:
-      cpu: 1000m
       memory: 512Mi
     requests:
       memory: 256Mi

--- a/.build/gcp-nais-prod.yaml
+++ b/.build/gcp-nais-prod.yaml
@@ -11,7 +11,6 @@ spec:
   replicas:
     min: 1
     max: 2
-    cpuThresholdPercentage: 50
   port: 8080
   liveness:
     path: /status
@@ -41,7 +40,6 @@ spec:
 
   resources:
     limits:
-      cpu: 1000m
       memory: 512Mi
     requests:
       memory: 256Mi


### PR DESCRIPTION
Anbefaling fra NAIS om at CPU throttle fjernes fra pod, men beholdes for requests: https://nav-it.slack.com/archives/C01DE3M9YBV/p1680172494569329

Artikkelen som det refereres til i meldingen fra NAIS beskriver hvorfor:
https://home.robusta.dev/blog/stop-using-cpu-limits

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-12306)