### PR TITLE
Oppgrader til Debian v12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/nodejs:18
+FROM gcr.io/distroless/nodejs18-debian12
 
 WORKDIR /var/server
 


### PR DESCRIPTION
`gcr.io/distroless/nodejs:18` bruker Debian11 som default, men denne inneholder en kritisk sårbar versjon av openssl. 

Hvis dere har aktivert SBOM-gererering vil feilene sannsynligvis dukke opp i Nais Console og DependencyTrack.

![image](https://github.com/user-attachments/assets/d88ef34f-edac-4992-8edf-d8a2778f6688)
