### PR TITLE
Sett lik memory request og limit

### DIFF
--- a/.nais/app-dev.yaml
+++ b/.nais/app-dev.yaml
@@ -42,4 +42,4 @@ spec:
     limits:
       memory: 256Mi
     requests:
-      memory: 128Mi
+      memory: 256Mi

--- a/.nais/app-prod.yaml
+++ b/.nais/app-prod.yaml
@@ -42,4 +42,4 @@ spec:
     limits:
       memory: 256Mi
     requests:
-      memory: 128Mi
+      memory: 256Mi


### PR DESCRIPTION
## Hva
Setter `resources.requests.memory` lik `resources.limits.memory` i nais.yaml-filene.

## Hvorfor
Anbefalt praksis for Kubernetes-ressurser er å ha requests og limits like for minne, se
https://www.flexera.com/blog/finops/kubernetes-limits-vs-requests-key-differences-and-how-they-work/#s5

Ingen CPU-limit er satt i denne appen, så det er ikke gjort endringer der.
